### PR TITLE
Use new caddy-ubi image for proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
 
 ENV CADDY_TLS_MODE http_port 8000
 
-COPY ./Caddyfile /opt/app-root/src/Caddyfile
+COPY ./Caddyfile /etc/caddy/Caddyfile
 
 CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-  FROM quay.io/cloudservices/caddy-ubi:ec1577c
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
 
-  ENV CADDY_TLS_MODE http_port 8000
+ENV CADDY_TLS_MODE http_port 8000
 
-  COPY ./Caddyfile /opt/app-root/src/Caddyfile
+COPY ./Caddyfile /opt/app-root/src/Caddyfile
 
-  CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]
+CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ ENV CADDY_TLS_MODE http_port 8000
 
 COPY ./Caddyfile /etc/caddy/Caddyfile
 
-CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]


### PR DESCRIPTION
Switching to the konflux built caddy-ubi image