### PR TITLE
updated caddy-ubi tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:94ba422
 
 ENV CADDY_TLS_MODE http_port 8000
 


### PR DESCRIPTION
Bump `caddy-ubi` to `94ba422` for proxy/frontend images.