### PR TITLE
glasswing: fix f001 — remove committed oauth-proxy cookie secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ and design decisions, see the [architecture documentation][architecture].
 [firelink-backend]: https://github.com/RedHatInsights/firelink-backend
 [firelink-frontend]: https://github.com/RedHatInsights/firelink-frontend
 [architecture]: ./ARCHITECTURE.md
+=======
+$ oc create secret generic firelink-proxy \
+    --from-literal=clientSecret=$(openssl rand -hex 32) -n $NS
+$ oc process -f deploy/deploy.yaml | oc apply -n $NS -f -
+```
+
+The `clientSecret` is used by oauth-proxy as the cookie-signing key, so it
+**must** be unique per environment and never committed to source control.
+When you deploy IRL you'll need the secret named `firelink-proxy` created
+elsewhere as it isn't in the template.

--- a/deploy/secret.yaml
+++ b/deploy/secret.yaml
@@ -1,9 +1,15 @@
+# DO NOT apply this file as-is. The clientSecret below is a placeholder.
+# oauth-proxy uses clientSecret as the HMAC key for signing the _oauth_proxy
+# session cookie; a publicly known value allows session forgery.
+#
+# Generate a unique secret per environment instead, e.g.:
+#   oc create secret generic firelink-proxy \
+#     --from-literal=clientSecret=$(openssl rand -hex 32) -n $NS
 apiVersion: v1
 kind: Secret
 metadata:
   name: firelink-proxy
 type: Opaque
-data:
-  clientSecret: >-
-    MTk2MDQyMzg1ZDYzMTBlNWI4YTZjZDcwYjM0MmFiMGI1ODc2MDI3NzlhMjJmNWMyZWMwNjBjMDg3ZmQ5ZTcxZA==
+stringData:
+  clientSecret: REPLACE_WITH_GENERATED_SECRET
 


### PR DESCRIPTION
deploy/secret.yaml shipped a real 256-bit clientSecret used by oauth-proxy as -cookie-secret-file (the HMAC key for the _oauth_proxy session cookie), and README instructed 'oc apply -f deploy/secret.yaml'. Any environment deployed that way has a publicly known cookie-signing key, allowing an internet attacker to forge a session cookie and bypass the OAuth/SAR gate.

Replace the committed value with an explicit placeholder + warning comment, and change the README ephemeral-env instructions to generate a fresh random secret via 'oc create secret ... openssl rand -hex 32' so no real key ever lives in the repo.

Addresses: analysis-results/findings/insights/firelink-proxy/firelink-proxy-triage.json#f001
CWEs: CWE-798, CWE-321, CWE-540